### PR TITLE
Remove trailing slash to avoid URLs with double slash

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const URL_ASSETS = 'https://raw.githubusercontent.com/ktquez/vue-social-chat/master/src/'
+export const URL_ASSETS = 'https://raw.githubusercontent.com/ktquez/vue-social-chat/master/src'
 
 export const HREF_BY_APP = {
   whatsapp: 'https://web.whatsapp.com/send?phone=%ph%&text=',


### PR DESCRIPTION
The trailing slash in the constant is concatenated with a string starting with a `/` [in the `ListChat` component](https://github.com/ktquez/vue-social-chat/blob/f1c89526d47cb5bdd149c888c33e5fc9849d615c/src/ListChat.vue#L22). Not a big deal, but that makes requests to URLs like https://raw.githubusercontent.com/ktquez/vue-social-chat/master/src//icons/close.svg (note the `src//icons`).
